### PR TITLE
Add ratios

### DIFF
--- a/src/i18n/ar.ts
+++ b/src/i18n/ar.ts
@@ -15,7 +15,7 @@ export default {
   nothingHere: "...عفوا. لا شيء هنا",
   redirect: "إعادة توجيه",
   members: "اعضاء",
-  mouse: "عادي",
+  mouse: "الفأر",
   shaman: "الشامان",
   profile: "الملف الشخصي",
   racing: "السباق",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -27,7 +27,7 @@ export default {
   redirect: "If you are not being redirected, {open}click here{close}",
 
   members: "Members",
-  mouse: "Normal",
+  mouse: "Mouse",
   shaman: "Shaman",
   profile: "Profile",
   racing: "Racing",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -116,6 +116,7 @@ export default {
   activeMemberCount: "Active member count",
   noMembers: "This tribe has no members",
   sinceLastSevenDays: "{sign}{value} since last 7 days",
+  ratio: "Ratio: {value}%",
 
   // Server healthcheck
   help: {

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -20,7 +20,7 @@ export default {
   nothingHere: "Ups. Aquí no hay nada...",
   redirect: "Si no estás siendo redirigido, {open}haz clic aquí{close}",
   members: "Miembros",
-  mouse: "Normal",
+  mouse: "Ratón",
   shaman: "Chamán",
   profile: "Perfil",
   racing: "Racing",

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -20,7 +20,7 @@ export default {
   nothingHere: "Oups. Y'a rien ici...",
   redirect: "Si vous n'êtes pas redirigé(e), {open}cliquez ici{close}",
   members: "Membres",
-  mouse: "Normal",
+  mouse: "Souris",
   shaman: "Chamane",
   profile: "Profil",
   racing: "Racing",

--- a/src/i18n/hu.ts
+++ b/src/i18n/hu.ts
@@ -20,7 +20,7 @@ export default {
   nothingHere: "Hoppá, valami nem stimmel...Váratlan hiba",
   redirect: "Ha nem kerül átirányításra, {open}kattintson ide{close} ",
   members: "Tagok",
-  mouse: "Normál",
+  mouse: "Egér",
   shaman: "Sámán",
   profile: "Profil",
   racing: "Verseny",

--- a/src/i18n/lv.ts
+++ b/src/i18n/lv.ts
@@ -20,7 +20,7 @@ export default {
   nothingHere: "Ups. Te nekā nav...",
   redirect: "Ja tu netiec pāradresēts, {open}nospied šeit{close}.",
   members: "Biedri",
-  mouse: "Normālais",
+  mouse: "Pele",
   shaman: "Šamanis",
   profile: "Profils",
   racing: "Racing",

--- a/src/i18n/pl.ts
+++ b/src/i18n/pl.ts
@@ -20,7 +20,7 @@ export default {
   nothingHere: "Ups. Tu nic nie ma...",
   redirect: "Jeżeli nie jesteś przekierowywany, {open}kliknij tutaj{close}",
   members: "Członkowie",
-  mouse: "Normalny",
+  mouse: "Mysz",
   shaman: "Szaman",
   profile: "Profil",
   racing: "Racing",

--- a/src/i18n/pt.ts
+++ b/src/i18n/pt.ts
@@ -20,7 +20,7 @@ export default {
   nothingHere: "Oops. Não há nada aqui...",
   redirect: "Se você não for redirecionado, {open} clique aqui {close}",
   members: "Membros",
-  mouse: "Normal",
+  mouse: "Rato",
   shaman: "Shaman",
   profile: "Perfil",
   racing: "Racing",

--- a/src/i18n/ro.ts
+++ b/src/i18n/ro.ts
@@ -20,7 +20,7 @@ export default {
   nothingHere: "Oops. Nu e nimic aici...",
   redirect: "Dacă nu ești redirecționat, {open}click aici{close}",
   members: "Membri",
-  mouse: "Normal",
+  mouse: "Șoarece",
   shaman: "Șaman",
   profile: "Porfil",
   racing: "Racing",

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -20,7 +20,7 @@ export default {
   nothingHere: "Упс. Здесь ничего нет..",
   redirect: "Если вы не были перенаправлены, {open}нажмите сюда{close}",
   members: "Пользователи",
-  mouse: "Обычный",
+  mouse: "Мышь",
   shaman: "Шаман",
   profile: "Профиль",
   racing: "Racing",

--- a/src/i18n/tr.ts
+++ b/src/i18n/tr.ts
@@ -20,7 +20,7 @@ export default {
   nothingHere: "Oops. Burada hiçbir şey yok...",
   redirect: "Yeniden yönlendirilemiyorsanız, {open} buraya tıklayın {close}",
   members: "Üyeler",
-  mouse: "Normal",
+  mouse: "Fare",
   shaman: "Şaman",
   profile: "Profil",
   racing: "Racing",

--- a/src/pages/Player/Profile.vue
+++ b/src/pages/Player/Profile.vue
@@ -52,7 +52,7 @@
       </div>
 
       <div class="q-gutter-y-sm">
-        <player-stats col="col-12 col-md-4" :stats="shamanStats" />
+        <player-stats :title="$t('shaman')" :stats="shamanStats" />
         <player-stats :title="$t('mouse')" :stats="mouseStats" />
         <player-stats :title="$t('racing')" :stats="racingStats" />
         <player-stats :title="$t('survivor')" :stats="survivorStats" />
@@ -156,7 +156,7 @@ export default class PlayerProfile extends mixins(Images) {
   }
 
   get shamanStats() {
-    const { savesNormal, savesHard, savesDivine } = this.player.stats.shaman;
+    const { savesNormal, savesHard, savesDivine, cheese } = this.player.stats.shaman;
     const progress = this.player.period.shaman;
     return [
       {
@@ -179,6 +179,13 @@ export default class PlayerProfile extends mixins(Images) {
         value: savesDivine,
         ratio: this.calculateRatio(savesDivine),
         progress: progress.savesDivine,
+      },
+      {
+        icon: this.getInventory(800),
+        title: this.$t("cheeseGatheredShaman"),
+        value: cheese,
+        ratio: this.calculateRatio(cheese),
+        progress: progress.cheese
       },
     ];
   }

--- a/src/pages/Player/Profile.vue
+++ b/src/pages/Player/Profile.vue
@@ -157,6 +157,7 @@ export default class PlayerProfile extends mixins(Images) {
 
   get shamanStats() {
     const { savesNormal, savesHard, savesDivine, cheese } = this.player.stats.shaman;
+    const rounds = this.player.stats.mouse.rounds;
     const progress = this.player.period.shaman;
     const progressRounds = this.player.period.mouse.rounds;
     return [
@@ -164,7 +165,7 @@ export default class PlayerProfile extends mixins(Images) {
         icon: this.getImage("x_transformice/x_divers/x_mc0.jpg"),
         title: this.$t("miceSavedNormal"),
         value: savesNormal,
-        ratio: this.calculateRatio(savesNormal),
+        ratio: this.calculateRatio(savesNormal, rounds),
         progress: progress.savesNormal,
         progressRatio: this.calculateRatio(progress.savesNormal, progressRounds),
       },
@@ -172,7 +173,7 @@ export default class PlayerProfile extends mixins(Images) {
         icon: this.getImage("x_transformice/x_divers/x_mc1.jpg"),
         title: this.$t("miceSavedHard"),
         value: savesHard,
-        ratio: this.calculateRatio(savesHard),
+        ratio: this.calculateRatio(savesHard, rounds),
         progress: progress.savesHard,
         progressRatio: this.calculateRatio(progress.savesHard, progressRounds),
       },
@@ -180,7 +181,7 @@ export default class PlayerProfile extends mixins(Images) {
         icon: this.getImage("x_transformice/x_divers/x_mc2.jpg"),
         title: this.$t("miceSavedDivine"),
         value: savesDivine,
-        ratio: this.calculateRatio(savesDivine),
+        ratio: this.calculateRatio(savesDivine, rounds),
         progress: progress.savesDivine,
         progressRatio: this.calculateRatio(progress.savesDivine, progressRounds),
       },
@@ -188,7 +189,7 @@ export default class PlayerProfile extends mixins(Images) {
         icon: this.getInventory(800),
         title: this.$t("cheeseGatheredShaman"),
         value: cheese,
-        ratio: this.calculateRatio(cheese),
+        ratio: this.calculateRatio(cheese, rounds),
         progress: progress.cheese,
         progressRatio: this.calculateRatio(progress.cheese, progressRounds),
       },
@@ -209,7 +210,7 @@ export default class PlayerProfile extends mixins(Images) {
         icon: this.getInventory(800),
         title: this.$t("gatheredCheese"),
         value: cheese,
-        ratio: this.calculateRatio(cheese),
+        ratio: this.calculateRatio(cheese, rounds),
         progress: progress.cheese,
         progressRatio: this.calculateRatio(progress.cheese, progress.rounds)
       },
@@ -217,7 +218,7 @@ export default class PlayerProfile extends mixins(Images) {
         icon: this.getInventory(2254),
         title: this.$t("cheeseGatheredFirst"),
         value: first,
-        ratio: this.calculateRatio(first),
+        ratio: this.calculateRatio(first, rounds),
         progress: progress.first,
         progressRatio: this.calculateRatio(progress.first, progress.rounds)
       },
@@ -337,8 +338,10 @@ export default class PlayerProfile extends mixins(Images) {
     return this.getLook(this.player);
   }
 
-  calculateRatio(stat: number, rounds: number = this.player.stats.mouse.rounds) {
+  calculateRatio(stat: number, rounds: number) {
     if (rounds > 0) return (stat / rounds * 100);
+
+    return 0;
   }
 }
 </script>

--- a/src/pages/Player/Profile.vue
+++ b/src/pages/Player/Profile.vue
@@ -158,6 +158,7 @@ export default class PlayerProfile extends mixins(Images) {
   get shamanStats() {
     const { savesNormal, savesHard, savesDivine, cheese } = this.player.stats.shaman;
     const progress = this.player.period.shaman;
+    const progressRounds = this.player.period.mouse.rounds;
     return [
       {
         icon: this.getImage("x_transformice/x_divers/x_mc0.jpg"),
@@ -165,6 +166,7 @@ export default class PlayerProfile extends mixins(Images) {
         value: savesNormal,
         ratio: this.calculateRatio(savesNormal),
         progress: progress.savesNormal,
+        progressRatio: this.calculateRatio(progress.savesNormal, progressRounds),
       },
       {
         icon: this.getImage("x_transformice/x_divers/x_mc1.jpg"),
@@ -172,6 +174,7 @@ export default class PlayerProfile extends mixins(Images) {
         value: savesHard,
         ratio: this.calculateRatio(savesHard),
         progress: progress.savesHard,
+        progressRatio: this.calculateRatio(progress.savesHard, progressRounds),
       },
       {
         icon: this.getImage("x_transformice/x_divers/x_mc2.jpg"),
@@ -179,13 +182,15 @@ export default class PlayerProfile extends mixins(Images) {
         value: savesDivine,
         ratio: this.calculateRatio(savesDivine),
         progress: progress.savesDivine,
+        progressRatio: this.calculateRatio(progress.savesDivine, progressRounds),
       },
       {
         icon: this.getInventory(800),
         title: this.$t("cheeseGatheredShaman"),
         value: cheese,
         ratio: this.calculateRatio(cheese),
-        progress: progress.cheese
+        progress: progress.cheese,
+        progressRatio: this.calculateRatio(progress.cheese, progressRounds),
       },
     ];
   }
@@ -206,6 +211,7 @@ export default class PlayerProfile extends mixins(Images) {
         value: cheese,
         ratio: this.calculateRatio(cheese),
         progress: progress.cheese,
+        progressRatio: this.calculateRatio(progress.cheese, progress.rounds)
       },
       {
         icon: this.getInventory(2254),
@@ -213,6 +219,7 @@ export default class PlayerProfile extends mixins(Images) {
         value: first,
         ratio: this.calculateRatio(first),
         progress: progress.first,
+        progressRatio: this.calculateRatio(progress.first, progress.rounds)
       },
       {
         icon: this.getInventory(2261),
@@ -239,6 +246,7 @@ export default class PlayerProfile extends mixins(Images) {
         value: finished,
         ratio: this.calculateRatio(finished, rounds),
         progress: progress.finished,
+        progressRatio: this.calculateRatio(progress.finished, progress.rounds),
       },
       {
         icon: this.getBadge(127),
@@ -246,6 +254,7 @@ export default class PlayerProfile extends mixins(Images) {
         value: podium,
         ratio: this.calculateRatio(podium, rounds),
         progress: progress.podium,
+        progressRatio: this.calculateRatio(progress.podium, progress.rounds),
       },
       {
         icon: this.getBadge(126),
@@ -253,6 +262,7 @@ export default class PlayerProfile extends mixins(Images) {
         value: first,
         ratio: this.calculateRatio(first, rounds),
         progress: progress.first,
+        progressRatio: this.calculateRatio(progress.first, progress.rounds),
       },
     ];
   }
@@ -273,6 +283,7 @@ export default class PlayerProfile extends mixins(Images) {
         value: shaman,
         ratio: this.calculateRatio(shaman, rounds),
         progress: progress.shaman,
+        progressRatio: this.calculateRatio(progress.shaman, progress.rounds),
       },
       {
         icon: this.getBadge(122),
@@ -280,6 +291,7 @@ export default class PlayerProfile extends mixins(Images) {
         value: killed,
         ratio: this.calculateRatio(killed, rounds),
         progress: progress.killed,
+        progressRatio: this.calculateRatio(progress.killed, progress.rounds),
       },
       {
         icon: this.getBadge(123),
@@ -287,6 +299,7 @@ export default class PlayerProfile extends mixins(Images) {
         value: survivor,
         ratio: this.calculateRatio(survivor, rounds),
         progress: progress.survivor,
+        progressRatio: this.calculateRatio(progress.survivor, progress.rounds),
       },
     ];
   }
@@ -307,6 +320,7 @@ export default class PlayerProfile extends mixins(Images) {
         value: finished,
         ratio: this.calculateRatio(finished, rounds),
         progress: progress.finished,
+        progressRatio: this.calculateRatio(progress.finished, progress.rounds),
       },
       {
         icon: this.getBadge(286),
@@ -314,6 +328,7 @@ export default class PlayerProfile extends mixins(Images) {
         value: points,
         ratio: this.calculateRatio(points, rounds),
         progress: progress.points,
+        progressRatio: this.calculateRatio(progress.points, progress.rounds),
       },
     ];
   }
@@ -323,7 +338,7 @@ export default class PlayerProfile extends mixins(Images) {
   }
 
   calculateRatio(stat: number, rounds: number = this.player.stats.mouse.rounds) {
-    if (rounds > 0) return (stat / rounds * 100).toFixed(1) + "%";
+    if (rounds > 0) return (stat / rounds * 100);
   }
 }
 </script>

--- a/src/pages/Player/Profile.vue
+++ b/src/pages/Player/Profile.vue
@@ -163,18 +163,21 @@ export default class PlayerProfile extends mixins(Images) {
         icon: this.getImage("x_transformice/x_divers/x_mc0.jpg"),
         title: this.$t("miceSavedNormal"),
         value: savesNormal,
+        ratio: this.calculateRatio(savesNormal),
         progress: progress.savesNormal,
       },
       {
         icon: this.getImage("x_transformice/x_divers/x_mc1.jpg"),
         title: this.$t("miceSavedHard"),
         value: savesHard,
+        ratio: this.calculateRatio(savesHard),
         progress: progress.savesHard,
       },
       {
         icon: this.getImage("x_transformice/x_divers/x_mc2.jpg"),
         title: this.$t("miceSavedDivine"),
         value: savesDivine,
+        ratio: this.calculateRatio(savesDivine),
         progress: progress.savesDivine,
       },
     ];
@@ -194,12 +197,14 @@ export default class PlayerProfile extends mixins(Images) {
         icon: this.getInventory(800),
         title: this.$t("gatheredCheese"),
         value: cheese,
+        ratio: this.calculateRatio(cheese),
         progress: progress.cheese,
       },
       {
         icon: this.getInventory(2254),
         title: this.$t("cheeseGatheredFirst"),
         value: first,
+        ratio: this.calculateRatio(first),
         progress: progress.first,
       },
       {
@@ -212,87 +217,95 @@ export default class PlayerProfile extends mixins(Images) {
   }
 
   get racingStats() {
-    const stats = this.player.stats.racing;
+    const { rounds, finished, podium, first } = this.player.stats.racing;
     const progress = this.player.period.racing;
     return [
       {
         icon: this.getBadge(124),
         title: this.$t("roundsPlayed"),
-        value: stats.rounds,
+        value: rounds,
         progress: progress.rounds,
       },
       {
         icon: this.getBadge(125),
         title: this.$t("completedRounds"),
-        value: stats.finished,
+        value: finished,
+        ratio: this.calculateRatio(finished, rounds),
         progress: progress.finished,
       },
       {
         icon: this.getBadge(127),
         title: this.$t("numberOfPodiums"),
-        value: stats.podium,
+        value: podium,
+        ratio: this.calculateRatio(podium, rounds),
         progress: progress.podium,
       },
       {
         icon: this.getBadge(126),
         title: this.$t("numberOfFirsts"),
-        value: stats.first,
+        value: first,
+        ratio: this.calculateRatio(first, rounds),
         progress: progress.first,
       },
     ];
   }
 
   get survivorStats() {
-    const stats = this.player.stats.survivor;
+    const { rounds, shaman, killed, survivor } = this.player.stats.survivor;
     const progress = this.player.period.survivor;
     return [
       {
         icon: this.getBadge(120),
         title: this.$t("roundsPlayed"),
-        value: stats.rounds,
+        value: rounds,
         progress: progress.rounds,
       },
       {
         icon: this.getBadge(121),
         title: this.$t("roundsAsShaman"),
-        value: stats.shaman,
+        value: shaman,
+        ratio: this.calculateRatio(shaman, rounds),
         progress: progress.shaman,
       },
       {
         icon: this.getBadge(122),
         title: this.$t("killedMice"),
-        value: stats.killed,
+        value: killed,
+        ratio: this.calculateRatio(killed, rounds),
         progress: progress.killed,
       },
       {
         icon: this.getBadge(123),
         title: this.$t("roundsSurvived"),
-        value: stats.survivor,
+        value: survivor,
+        ratio: this.calculateRatio(survivor, rounds),
         progress: progress.survivor,
       },
     ];
   }
 
   get defilanteStats() {
-    const stats = this.player.stats.defilante;
+    const { rounds, finished, points } = this.player.stats.defilante;
     const progress = this.player.period.defilante;
     return [
       {
         icon: this.getBadge(288),
         title: this.$t("roundsPlayed"),
-        value: stats.rounds,
+        value: rounds,
         progress: progress.rounds,
       },
       {
         icon: this.getBadge(287),
         title: this.$t("completedRounds"),
-        value: stats.finished,
+        value: finished,
+        ratio: this.calculateRatio(finished, rounds),
         progress: progress.finished,
       },
       {
         icon: this.getBadge(286),
         title: this.$t("pointsGathered"),
-        value: stats.points,
+        value: points,
+        ratio: this.calculateRatio(points, rounds),
         progress: progress.points,
       },
     ];
@@ -300,6 +313,10 @@ export default class PlayerProfile extends mixins(Images) {
 
   get look() {
     return this.getLook(this.player);
+  }
+
+  calculateRatio(stat: number, rounds: number = this.player.stats.mouse.rounds) {
+    if (rounds > 0) return (stat / rounds * 100).toFixed(1) + "%";
   }
 }
 </script>

--- a/src/pages/Player/components/Stats.vue
+++ b/src/pages/Player/components/Stats.vue
@@ -16,8 +16,9 @@
             <q-item-section class="q-ml-md">
               <q-item-label>{{ s.title }}</q-item-label>
               <q-item-label class="text-h6">
-                {{ s.value }}
-                <span v-if="s.ratio" class="text-caption q-ml-xs">{{ $t("ratio", { value: s.ratio.toFixed(1) }) }}</span>
+                <span class="q-mr-sm">{{ s.value }}</span>
+                <wbr>
+                <span v-if="s.ratio" class="text-caption text-no-wrap">{{ $t("ratio", { value: s.ratio.toFixed(1) }) }}</span>
               </q-item-label>
               <q-item-label caption v-if="s.progress" class="text-green">
                 {{ $t("sinceLastSevenDays", { sign: "+", value: s.progress }) }}

--- a/src/pages/Player/components/Stats.vue
+++ b/src/pages/Player/components/Stats.vue
@@ -3,8 +3,8 @@
     <div class="text-grey q-pl-sm">{{ title }}</div>
     <div class="row">
       <div v-for="(s, i) in stats" :key="i" class="q-pa-xs" :class="col">
-        <q-card flat bordered>
-          <q-item>
+        <q-card flat bordered class="full-height">
+          <q-item class="full-height">
             <q-item-section avatar v-if="s.icon">
               <q-avatar square>
                 <img :src="s.icon" />
@@ -17,13 +17,14 @@
               <q-item-label>{{ s.title }}</q-item-label>
               <q-item-label class="text-h6">
                 {{ s.value }}
-                <span v-if="s.ratio" class="text-caption q-ml-xs">Ratio: {{ s.ratio }}</span>
+                <span v-if="s.ratio" class="text-caption q-ml-xs">{{ $t("ratio", { value: s.ratio.toFixed(1) }) }}</span>
               </q-item-label>
-              <q-item-label caption class="text-green">
-                <template v-if="s.progress">
-                  {{ $t("sinceLastSevenDays", { sign: "+", value: s.progress }) }}
+              <q-item-label caption v-if="s.progress" class="text-green">
+                {{ $t("sinceLastSevenDays", { sign: "+", value: s.progress }) }}
+                <br>
+                <template v-if="s.progressRatio">
+                  {{ $t("ratio", { value: s.progressRatio.toFixed(1) }) }}
                 </template>
-                <wbr />
               </q-item-label>
             </q-item-section>
           </q-item>
@@ -43,8 +44,9 @@ export default class Stats extends Vue {
     icon: string;
     title: string;
     value: number;
-    ratio: string;
+    ratio: number;
     progress: number;
+    progressRatio: number;
   }[];
 }
 </script>

--- a/src/pages/Player/components/Stats.vue
+++ b/src/pages/Player/components/Stats.vue
@@ -15,7 +15,10 @@
 
             <q-item-section class="q-ml-md">
               <q-item-label>{{ s.title }}</q-item-label>
-              <q-item-label class="text-h6">{{ s.value }}</q-item-label>
+              <q-item-label class="text-h6">
+                {{ s.value }}
+                <span v-if="s.ratio" class="text-caption q-ml-xs">Ratio: {{ s.ratio }}</span>
+              </q-item-label>
               <q-item-label caption class="text-green">
                 <template v-if="s.progress">
                   {{ $t("sinceLastSevenDays", { sign: "+", value: s.progress }) }}
@@ -40,6 +43,7 @@ export default class Stats extends Vue {
     icon: string;
     title: string;
     value: number;
+    ratio: string;
     progress: number;
   }[];
 }

--- a/src/pages/Tribe/Profile.vue
+++ b/src/pages/Tribe/Profile.vue
@@ -35,7 +35,7 @@
     <div class="col-12 col-lg-10 q-gutter-y-md">
       <div class="q-gutter-y-sm">
         <tribe-stats col="col-12 col-sm-6" :stats="memberStats" />
-        <tribe-stats col="col-12 col-sm-6 col-md-4" :stats="shamanStats" />
+        <tribe-stats :title="$t('shaman')" :stats="shamanStats" />
         <tribe-stats :title="$t('mouse')" :stats="mouseStats" />
         <tribe-stats :title="$t('racing')" :stats="racingStats" />
         <tribe-stats :title="$t('survivor')" :stats="survivorStats" />
@@ -116,26 +116,36 @@ export default class TribeProfile extends mixins(Images) {
   }
 
   get shamanStats() {
-    const { savesNormal, savesHard, savesDivine } = this.tribe.stats.shaman;
+    const { savesNormal, savesHard, savesDivine, cheese } = this.tribe.stats.shaman;
     const progress = this.tribe.period.shaman;
     return [
       {
         icon: this.getImage("x_transformice/x_divers/x_mc0.jpg"),
         title: this.$t("miceSavedNormal"),
         value: savesNormal,
+        ratio: this.calculateRatio(savesNormal),
         progress: progress.savesNormal,
       },
       {
         icon: this.getImage("x_transformice/x_divers/x_mc1.jpg"),
         title: this.$t("miceSavedHard"),
         value: savesHard,
+        ratio: this.calculateRatio(savesHard),
         progress: progress.savesHard,
       },
       {
         icon: this.getImage("x_transformice/x_divers/x_mc2.jpg"),
         title: this.$t("miceSavedDivine"),
         value: savesDivine,
+        ratio: this.calculateRatio(savesDivine),
         progress: progress.savesDivine,
+      },
+      {
+        icon: this.getInventory(800),
+        title: this.$t("cheeseGatheredShaman"),
+        value: cheese,
+        ratio: this.calculateRatio(cheese),
+        progress: progress.cheese,
       },
     ];
   }
@@ -154,12 +164,14 @@ export default class TribeProfile extends mixins(Images) {
         icon: this.getInventory(800),
         title: this.$t("gatheredCheese"),
         value: cheese,
+        ratio: this.calculateRatio(cheese),
         progress: progress.cheese,
       },
       {
         icon: this.getInventory(2254),
         title: this.$t("cheeseGatheredFirst"),
         value: first,
+        ratio: this.calculateRatio(first),
         progress: progress.first,
       },
       {
@@ -172,90 +184,102 @@ export default class TribeProfile extends mixins(Images) {
   }
 
   get racingStats() {
-    const stats = this.tribe.stats.racing;
+    const { rounds, finished, podium, first } = this.tribe.stats.racing;
     const progress = this.tribe.period.racing;
     return [
       {
         icon: this.getBadge(124),
         title: this.$t("roundsPlayed"),
-        value: stats.rounds,
+        value: rounds,
         progress: progress.rounds,
       },
       {
         icon: this.getBadge(125),
         title: this.$t("completedRounds"),
-        value: stats.finished,
+        value: finished,
+        ratio: this.calculateRatio(finished, rounds),
         progress: progress.finished,
       },
       {
         icon: this.getBadge(127),
         title: this.$t("numberOfPodiums"),
-        value: stats.podium,
+        value: podium,
+        ratio: this.calculateRatio(podium, rounds),
         progress: progress.podium,
       },
       {
         icon: this.getBadge(126),
         title: this.$t("numberOfFirsts"),
-        value: stats.first,
+        value: first,
+        ratio: this.calculateRatio(first, rounds),
         progress: progress.first,
       },
     ];
   }
 
   get survivorStats() {
-    const stats = this.tribe.stats.survivor;
+    const { rounds, shaman, killed, survivor } = this.tribe.stats.survivor;
     const progress = this.tribe.period.survivor;
     return [
       {
         icon: this.getBadge(120),
         title: this.$t("roundsPlayed"),
-        value: stats.rounds,
+        value: rounds,
         progress: progress.rounds,
       },
       {
         icon: this.getBadge(121),
         title: this.$t("roundsAsShaman"),
-        value: stats.shaman,
+        value: shaman,
+        ratio: this.calculateRatio(shaman, rounds),
         progress: progress.shaman,
       },
       {
         icon: this.getBadge(122),
         title: this.$t("killedMice"),
-        value: stats.killed,
+        value: killed,
+        ratio: this.calculateRatio(killed, rounds),
         progress: progress.killed,
       },
       {
         icon: this.getBadge(123),
         title: this.$t("roundsSurvived"),
-        value: stats.survivor,
+        value: survivor,
+        ratio: this.calculateRatio(survivor, rounds),
         progress: progress.survivor,
       },
     ];
   }
 
   get defilanteStats() {
-    const stats = this.tribe.stats.defilante;
+    const { rounds, finished, points } = this.tribe.stats.defilante;
     const progress = this.tribe.period.defilante;
     return [
       {
         icon: this.getBadge(288),
         title: this.$t("roundsPlayed"),
-        value: stats.rounds,
+        value: rounds,
         progress: progress.rounds,
       },
       {
         icon: this.getBadge(287),
         title: this.$t("completedRounds"),
-        value: stats.finished,
+        value: finished,
+        ratio: this.calculateRatio(finished, rounds),
         progress: progress.finished,
       },
       {
         icon: this.getBadge(286),
         title: this.$t("pointsGathered"),
-        value: stats.points,
+        value: points,
+        ratio: this.calculateRatio(points, rounds),
         progress: progress.points,
       },
     ];
+  }
+
+  calculateRatio(stat: number, rounds: number = this.tribe.stats.mouse.rounds) {
+    if (rounds > 0) return (stat / rounds * 100);
   }
 }
 </script>

--- a/src/pages/Tribe/Profile.vue
+++ b/src/pages/Tribe/Profile.vue
@@ -117,34 +117,35 @@ export default class TribeProfile extends mixins(Images) {
 
   get shamanStats() {
     const { savesNormal, savesHard, savesDivine, cheese } = this.tribe.stats.shaman;
+    const rounds = this.tribe.stats.mouse.rounds;
     const progress = this.tribe.period.shaman;
     return [
       {
         icon: this.getImage("x_transformice/x_divers/x_mc0.jpg"),
         title: this.$t("miceSavedNormal"),
         value: savesNormal,
-        ratio: this.calculateRatio(savesNormal),
+        ratio: this.calculateRatio(savesNormal, rounds),
         progress: progress.savesNormal,
       },
       {
         icon: this.getImage("x_transformice/x_divers/x_mc1.jpg"),
         title: this.$t("miceSavedHard"),
         value: savesHard,
-        ratio: this.calculateRatio(savesHard),
+        ratio: this.calculateRatio(savesHard, rounds),
         progress: progress.savesHard,
       },
       {
         icon: this.getImage("x_transformice/x_divers/x_mc2.jpg"),
         title: this.$t("miceSavedDivine"),
         value: savesDivine,
-        ratio: this.calculateRatio(savesDivine),
+        ratio: this.calculateRatio(savesDivine, rounds),
         progress: progress.savesDivine,
       },
       {
         icon: this.getInventory(800),
         title: this.$t("cheeseGatheredShaman"),
         value: cheese,
-        ratio: this.calculateRatio(cheese),
+        ratio: this.calculateRatio(cheese, rounds),
         progress: progress.cheese,
       },
     ];
@@ -164,14 +165,14 @@ export default class TribeProfile extends mixins(Images) {
         icon: this.getInventory(800),
         title: this.$t("gatheredCheese"),
         value: cheese,
-        ratio: this.calculateRatio(cheese),
+        ratio: this.calculateRatio(cheese, rounds),
         progress: progress.cheese,
       },
       {
         icon: this.getInventory(2254),
         title: this.$t("cheeseGatheredFirst"),
         value: first,
-        ratio: this.calculateRatio(first),
+        ratio: this.calculateRatio(first, rounds),
         progress: progress.first,
       },
       {
@@ -278,8 +279,10 @@ export default class TribeProfile extends mixins(Images) {
     ];
   }
 
-  calculateRatio(stat: number, rounds: number = this.tribe.stats.mouse.rounds) {
+  calculateRatio(stat: number, rounds: number) {
     if (rounds > 0) return (stat / rounds * 100);
+
+    return 0;
   }
 }
 </script>

--- a/src/pages/Tribe/components/Stats.vue
+++ b/src/pages/Tribe/components/Stats.vue
@@ -3,8 +3,8 @@
     <div class="text-grey q-pl-sm">{{ title }}</div>
     <div class="row">
       <div v-for="(s, i) in stats" :key="i" class="q-pa-xs" :class="col">
-        <q-card flat bordered>
-          <q-item>
+        <q-card flat bordered class="full-height">
+          <q-item class="full-height">
             <q-item-section avatar v-if="s.icon">
               <q-avatar square>
                 <img :src="s.icon" />
@@ -15,17 +15,17 @@
 
             <q-item-section class="q-ml-md">
               <q-item-label>{{ s.title }}</q-item-label>
-              <q-item-label class="text-h6">{{ s.value }}</q-item-label>
-              <q-item-label caption :class="s.progress >= 0 ? 'text-green' : 'text-red'">
-                <template v-if="s.progress !== 0">
-                  {{
-                    $t("sinceLastSevenDays", {
-                      sign: s.progress >= 0 ? "+" : "",
-                      value: s.progress,
-                    })
-                  }}
-                </template>
-                <wbr />
+              <q-item-label class="text-h6">
+                {{ s.value }}
+                <span v-if="s.ratio" class="text-caption q-ml-xs">{{ $t("ratio", { value: s.ratio.toFixed(1) }) }}</span>
+              </q-item-label>
+              <q-item-label caption v-if="s.progress !== 0" :class="s.progress >= 0 ? 'text-green' : 'text-red'">
+                {{
+                  $t("sinceLastSevenDays", {
+                    sign: s.progress >= 0 ? "+" : "",
+                    value: s.progress,
+                  })
+                }}
               </q-item-label>
             </q-item-section>
           </q-item>
@@ -45,6 +45,7 @@ export default class Stats extends Vue {
     icon: string;
     title: string;
     value: number;
+    ratio: number;
     progress: number;
   }[];
 }

--- a/src/pages/Tribe/components/Stats.vue
+++ b/src/pages/Tribe/components/Stats.vue
@@ -16,8 +16,9 @@
             <q-item-section class="q-ml-md">
               <q-item-label>{{ s.title }}</q-item-label>
               <q-item-label class="text-h6">
-                {{ s.value }}
-                <span v-if="s.ratio" class="text-caption q-ml-xs">{{ $t("ratio", { value: s.ratio.toFixed(1) }) }}</span>
+                <span class="q-mr-sm">{{ s.value }}</span>
+                <wbr>
+                <span v-if="s.ratio" class="text-caption text-no-wrap">{{ $t("ratio", { value: s.ratio.toFixed(1) }) }}</span>
               </q-item-label>
               <q-item-label caption v-if="s.progress !== 0" :class="s.progress >= 0 ? 'text-green' : 'text-red'">
                 {{


### PR DESCRIPTION
This PR primarily focuses on adding ratios to CFM, but also revises some smaller things:

- [x] Add mouse ratios to all stats (that make sense)
- [x] Add progress ratios to the same stats
- [x] Add tribe ratios
- [x] Add shaman title to the shaman stats
- [x] Add cheese gathered as shaman to shaman stats
- [x] Rename `Normal` to `Mouse` also in the profile

Sneak peek:
<details>
<summary>1440px</summary>
<img width="1440" alt="1440px" src="https://user-images.githubusercontent.com/31915276/135752641-bf859084-e00d-4b3b-88d2-ac63a38aac06.png">
</details>

<details>
<summary>320px (Beware, tall screenshot)</summary>
<img width="320" alt="320px" src="https://user-images.githubusercontent.com/31915276/135752682-b53b72df-1178-410b-b5d9-71334e95679d.png">
</details>

Tribe ratios (only overall stats, progress ratios wouldn't make sense due to people being able to leave tribes):
<details>
<summary>1440px</summary>
<img width="1440" alt="1440px" src="https://user-images.githubusercontent.com/31915276/135761861-48fce830-872f-437e-bee9-5f19edce2853.png">
</details>

<details>
<summary>320px</summary>
<img width="320" alt="320px" src="https://user-images.githubusercontent.com/31915276/135761898-cbd51e99-f50f-49ef-b9c4-2a7dd3c7956f.png">
</details>

Disclaimer: Profile in the above screenshots has been chosen due to its high variety of stats/changes.