### PR TITLE
Change Top 10 Players to stats instead of overall

### DIFF
--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -157,7 +157,7 @@ export default class PageIndex extends Vue {
   }
 
   async fetchLeaderboard() {
-    const response = await PlayersService.getLeaderboard("overall", "overall", {
+    const response = await PlayersService.getLeaderboard("stats", "overall", {
       page: 1,
       limit: 10,
     });


### PR DESCRIPTION
When I made the `stats` leaderboard the default I forgot to change also the Top 10 Players on the landing page. This small PR fixes that.